### PR TITLE
fix image markdown in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # little-rat
 Small chrome extension to monitor other extensions' network calls
 ### Installation (Chrome/Chromium/Arc/etc)
-- Download the ![ZIP](https://github.com/dnakov/little-rat/archive/refs/heads/main.zip) of this repo.
+- Download the [ZIP](https://github.com/dnakov/little-rat/archive/refs/heads/main.zip) of this repo.
 - Unzip
 - Go to chromium/chrome *Extensions*.
 - Click to check *Developer mode*.


### PR DESCRIPTION
very small fix so that the `![ZIP]` markdown would not appear as a broken image in github

i.e. to fix this:

![image](https://github.com/dnakov/little-rat/assets/1017304/16359bf5-b709-4f10-8738-7b394c31963a)

cheers! thanks for your work