### PR TITLE
Add a rate limiter to popup page refresh

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -3,6 +3,7 @@ let popup;
 let muted;
 let requests = {};
 let needSave = false;
+let lastNotify = +new Date();
 
 chrome.storage.local.get(s => {
   muted = s?.muted || {};
@@ -16,8 +17,10 @@ chrome.runtime.onMessage.addListener((message) => {
   }
 });
 
-async function notifyPopup() {
-  if (popup) {
+async function notifyPopup(directRun=false) {
+  let now = +new Date();
+  if ((directRun || now - lastNotify > 1000) && popup) {
+    lastNotify = now;
     chrome.runtime.sendMessage({ type: 'init', data: await getExtensions() });
   }
 }
@@ -82,7 +85,7 @@ chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
     await chrome.storage.local.set({ requests });
   }
   await sendResponse();
-  await notifyPopup();
+  await notifyPopup(true);
 });
 
 
@@ -93,5 +96,5 @@ chrome.runtime.onConnect.addListener(async (port) => {
   popup = port;
   badgeNum = 0;
   chrome.action.setBadgeText({ text: '' });
-  await notifyPopup();
+  await notifyPopup(true);
 });


### PR DESCRIPTION
Refresh popup page every one second. Some extensions are crazy, and will make huge amount of network calls. That will cause popup refresh stuck and unexpected exceptions.

Crazy extension:

![Screenshot 2023-08-15 214648](https://github.com/dnakov/little-rat/assets/7422992/8519317a-7ca4-46ac-9d23-9e8da107e8f3)

Exception on `sendMessage`:

> uncaught (in promise) error: could not establish connection. receiving end does not exist.